### PR TITLE
Fix null user role access in users index

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -54,6 +54,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'user_role' => 'integer',
         ];
     }
 
@@ -70,7 +71,7 @@ class User extends Authenticatable
 
     public function role()
     {
-        return $this->belongsTo(\App\Models\UserRole::class, 'user_role', 'id'); // Adjust 'id' if your PK is different
+        return $this->belongsTo(\App\Models\UserRole::class, 'user_role', 'id');
     }
 
     public function hasRight($page, $action)
@@ -84,6 +85,14 @@ class User extends Authenticatable
             return $access[$rightColumn] == 1;
         }
         return false;
+    }
+
+    /**
+     * Check if user has admin privileges
+     */
+    public function isAdmin()
+    {
+        return $this->role && in_array(strtolower($this->role->ur_name), ['admin', 'administrator', 'supervisor']);
     }
 }
 

--- a/resources/views/access_rights/index.blade.php
+++ b/resources/views/access_rights/index.blade.php
@@ -20,7 +20,7 @@
             <tr>
                 <td>{{ $role->ur_name }}</td>
                 <td>
-                    @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+                    @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
                         <a href="{{ route('access-rights.edit', $role->id) }}" class="btn btn-sm btn-primary">Edit Privileges</a>
                     @endif
                 </td>

--- a/resources/views/branches/index.blade.php
+++ b/resources/views/branches/index.blade.php
@@ -9,7 +9,7 @@
         <div class="alert alert-success">{{ session('status') }}</div>
     @endif
     <div class="mb-3">
-        @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+        @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
             <a href="{{ route('branches.create') }}" class="btn btn-success">Add Branch</a>
         @endif
     </div>
@@ -29,7 +29,7 @@
                 <td>{{ $branch->branch_added_by }}</td>
                 <td>{{ $branch->branch_date_added }}</td>
                 <td>
-                    @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+                    @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
                         <a href="{{ route('branches.edit', $branch->id) }}" class="btn btn-sm btn-primary">Edit</a>
                         <form action="{{ route('branches.destroy', $branch->id) }}" method="POST" style="display:inline-block;" onsubmit="return confirm('Are you sure you want to delete this branch?');">
                             @csrf

--- a/resources/views/departments/index.blade.php
+++ b/resources/views/departments/index.blade.php
@@ -9,7 +9,7 @@
         <div class="alert alert-success">{{ session('status') }}</div>
     @endif
     <div class="mb-3">
-        @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+        @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
             <a href="{{ route('departments.create') }}" class="btn btn-success">Add Department</a>
         @endif
     </div>
@@ -29,7 +29,7 @@
                 <td>{{ $department->dept_added_by }}</td>
                 <td>{{ $department->dept_date_added }}</td>
                 <td>
-                    @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+                    @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
                         <a href="{{ route('departments.edit', $department->id) }}" class="btn btn-sm btn-primary">Edit</a>
                         <form action="{{ route('departments.destroy', $department->id) }}" method="POST" style="display:inline-block;" onsubmit="return confirm('Are you sure you want to delete this department?');">
                             @csrf

--- a/resources/views/designations/index.blade.php
+++ b/resources/views/designations/index.blade.php
@@ -9,7 +9,7 @@
         <div class="alert alert-success">{{ session('status') }}</div>
     @endif
     <div class="mb-3">
-        @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+        @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
             <a href="{{ route('designations.create') }}" class="btn btn-success">Add Designation</a>
         @endif
     </div>
@@ -29,7 +29,7 @@
                 <td>{{ $designation->designation_added_by }}</td>
                 <td>{{ $designation->designation_date_added }}</td>
                 <td>
-                    @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+                    @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
                         <a href="{{ route('designations.edit', $designation->id) }}" class="btn btn-sm btn-primary">Edit</a>
                         <form action="{{ route('designations.destroy', $designation->id) }}" method="POST" style="display:inline-block;">
                             @csrf

--- a/resources/views/user_roles/index.blade.php
+++ b/resources/views/user_roles/index.blade.php
@@ -9,7 +9,7 @@
         <div class="alert alert-success">{{ session('status') }}</div>
     @endif
     <div class="mb-3">
-        @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+        @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
             <a href="{{ route('user-roles.create') }}" class="btn btn-success">Add Role</a>
         @endif
     </div>
@@ -29,7 +29,7 @@
                 <td>{{ $role->ur_added_by }}</td>
                 <td>{{ $role->ur_date_added }}</td>
                 <td>
-                    @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+                    @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
                         <a href="{{ route('user-roles.edit', $role->id) }}" class="btn btn-sm btn-primary">Edit</a>
                         <form action="{{ route('user-roles.destroy', $role->id) }}" method="POST" style="display:inline-block;">
                             @csrf

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -6,7 +6,7 @@
 <div class="container">
     <h2>System Users</h2>
     <div class="mb-3">
-        @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+        @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
             <a href="{{ route('users.create') }}" class="btn btn-success">Add User</a>
         @endif
     </div>
@@ -49,7 +49,7 @@
                 <td>{{ $user->user_active ? 'Active' : 'Locked' }}</td>
                 <td>{{ $user->role ? $user->role->ur_name : '' }}</td>
                 <td>
-                    @if(auth()->check() && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
+                    @if(auth()->check() && auth()->user()->role && in_array(strtolower(auth()->user()->role->ur_name), ['admin', 'administrator', 'supervisor']))
                         <a href="{{ route('users.edit', $user->id) }}" class="btn btn-primary btn-sm">Edit</a>
                         <form action="{{ route('users.destroy', $user->id) }}" method="POST" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this user?');">
                             @csrf


### PR DESCRIPTION
Fix "Attempt to read property 'ur_name' on null" error by adding null checks and casting `user_role` to integer.

The error occurred because the `role` relationship on the `User` model could return null, and the blade templates were attempting to access `ur_name` without a prior null check. Additionally, the `user_role` column in the `users` table was a string, which could lead to issues when matching against the integer `id` in the `user_roles` table. This PR adds explicit integer casting for `user_role` in the `User` model and introduces null checks in all affected blade templates to prevent the error. A helper `isAdmin()` method was also added to the `User` model for cleaner privilege checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c06c792-31a8-4e76-a2c3-942dab8e706a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c06c792-31a8-4e76-a2c3-942dab8e706a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>